### PR TITLE
Add IEC-61851 Charging Status Sensor

### DIFF
--- a/custom_components/volvo_cars/const.py
+++ b/custom_components/volvo_cars/const.py
@@ -44,3 +44,13 @@ OPT_UNIT_MPG_US = "mpg_us"
 SERVICE_REFRESH_DATA = "refresh_data"
 SERVICE_PARAM_DATA = "data"
 SERVICE_PARAM_ENTRY = "entry"
+
+# IEC-61851 converting
+DICT_CHARGE_STATUS_MAPPING: dict = {
+    "charging_system_charging": "C",
+    "charging_system_done": "B",
+    "charging_system_fault": "E",
+    "charging_system_idle": "B",
+    "charging_system_scheduled": "B",
+    "charging_system_unspecified": "A",
+}

--- a/custom_components/volvo_cars/sensor.py
+++ b/custom_components/volvo_cars/sensor.py
@@ -30,6 +30,7 @@ from .const import (
     OPT_UNIT_LITER_PER_100KM,
     OPT_UNIT_MPG_UK,
     OPT_UNIT_MPG_US,
+    DICT_CHARGE_STATUS_MAPPING,
 )
 from .coordinator import VolvoCarsConfigEntry, VolvoCarsDataCoordinator
 from .entity import VolvoCarsEntity, value_to_translation_key
@@ -90,6 +91,11 @@ def _convert_energy_consumption(
         converted_value = (100 / Decimal(1.609344) / value) if value else Decimal(0)
 
     return round(converted_value, 1)
+
+
+# convert charging system status in IEC-61851
+def _convert_charging_system(field: VolvoCarsValue, entry: VolvoCarsConfigEntry) -> str:
+    return DICT_CHARGE_STATUS_MAPPING.get(str(field.value), "A")
 
 
 def _determine_fuel_consumption_unit(entry: VolvoCarsConfigEntry) -> str:
@@ -275,6 +281,23 @@ SENSORS: tuple[VolvoCarsSensorDescription, ...] = (
         ],
         icon="mdi:ev-station",
         available_fn=lambda vehicle: vehicle.has_battery_engine(),
+    ),
+    VolvoCarsSensorDescription(
+        key="charging_system_status_normalized",
+        translation_key="charging_system_status_normalized",
+        api_field="chargingSystemStatus",
+        device_class=SensorDeviceClass.ENUM,
+        options=[
+            "A",
+            "B",
+            "C",
+            "D",
+            "E",
+            "F",
+        ],
+        icon="mdi:ev-station",
+        available_fn=lambda vehicle: vehicle.has_battery_engine(),
+        value_fn=_convert_charging_system,
     ),
     VolvoCarsSensorDescription(
         key="distance_to_empty_battery",

--- a/custom_components/volvo_cars/strings.json
+++ b/custom_components/volvo_cars/strings.json
@@ -1030,6 +1030,24 @@
                     }
                 }
             },
+            "charging_system_status_normalized": {
+                "name": "Charging status Normalized",
+                "state": {
+                    "A": "[%key:common::Unknown%]",
+                    "B": "Idle",
+                    "C": "Charging",
+                    "E": "[%key:common::error%]",
+                    "F": "[%key:common::error%]"
+                },
+                "state_attributes": {
+                    "api_timestamp": {
+                        "name": "[%key:common::api_timestamp%]"
+                    },
+                    "last_refresh": {
+                        "name": "[%key:common::last_refresh%]"
+                    }
+                }
+            },
             "charging_system_status": {
                 "name": "Charging status",
                 "state": {


### PR DESCRIPTION
It exists IEC-61851 for a Charging Status, I was so freely and tried to convert the Volvo Charge Status to this norm. 
Hopefully correct, so it can used for example in EVCC.io without an converter